### PR TITLE
Fix login/logout redirects to preserve base URL

### DIFF
--- a/contacts.html
+++ b/contacts.html
@@ -1126,7 +1126,7 @@
             if (confirm('Czy na pewno chcesz się wylogować?')) {
                 localStorage.removeItem('authToken');
                 localStorage.removeItem('userData');
-                window.location.href = '/index.html';
+                window.location.href = 'index.html';
             }
         }
 
@@ -1136,7 +1136,7 @@
         document.addEventListener('DOMContentLoaded', function() {
             const token = localStorage.getItem('authToken');
             if (!token) {
-                window.location.href = '/index.html';
+                window.location.href = 'index.html';
                 return;
             }
 

--- a/index.html
+++ b/index.html
@@ -664,10 +664,10 @@
             // Pokaż komunikat sukcesu
             elements.loginForm.style.display = 'none';
             elements.successMessage.classList.add('show');
-            
+
             // Przekieruj do widoku kontaktów po pomyślnym logowaniu
             setTimeout(() => {
-                window.location.href = '/contacts.html';
+                window.location.href = 'contacts.html';
             }, 1500);
         }
 


### PR DESCRIPTION
## Summary
- Use relative paths in login success redirect
- Use relative paths for logout and auth checks to keep base URL

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ad64e96808832690fceabd6951c78c