### PR TITLE
Translate wrong password error message to Polish

### DIFF
--- a/index.html
+++ b/index.html
@@ -641,7 +641,11 @@
                 });
 
                 if (error) {
-                    return { success: false, error: error.message };
+                    const translatedErrors = {
+                        'Invalid login credentials': 'Nieprawidłowy email lub hasło'
+                    };
+                    const translatedMessage = translatedErrors[error.message] || error.message;
+                    return { success: false, error: translatedMessage };
                 }
 
                 return { success: true, data };


### PR DESCRIPTION
## Summary
- translate Supabase invalid login message to a Polish string

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ad68573b5483269180200444bf158c