### PR TITLE
Remove send email button from contact details view

### DIFF
--- a/contact-details.html
+++ b/contact-details.html
@@ -815,12 +815,6 @@
                         </svg>
                         <span>Edytuj</span>
                     </button>
-                    <button class="btn-action primary">
-                        <svg width="16" height="16" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 8l7.89 5.26a2 2 0 002.22 0L21 8M5 19h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z"></path>
-                        </svg>
-                        <span>Wyślij email</span>
-                    </button>
                 </div>
             </div>
         </div>


### PR DESCRIPTION
## Summary
- remove "Wyślij email" button from contact details header

## Testing
- `npm test` *(fails: missing package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ad6f2db188832695a54f7841f0d21e