### PR TITLE
Add note creation modal

### DIFF
--- a/contact-details.html
+++ b/contact-details.html
@@ -511,6 +511,165 @@
             color: #6b7280;
             line-height: 1.6;
         }
+        .note-title {
+            font-weight: 600;
+            color: #1a1a1a;
+            margin-bottom: 8px;
+        }
+
+        /* Modal styles */
+        .modal {
+            display: none;
+            position: fixed;
+            top: 0;
+            left: 0;
+            width: 100%;
+            height: 100%;
+            background: rgba(0, 0, 0, 0.5);
+            z-index: 1000;
+            animation: fadeIn 0.3s;
+        }
+
+        .modal.show {
+            display: flex;
+            align-items: center;
+            justify-content: center;
+        }
+
+        @keyframes fadeIn {
+            from { opacity: 0; }
+            to { opacity: 1; }
+        }
+
+        .modal-content {
+            background: white;
+            border-radius: 16px;
+            width: 90%;
+            max-width: 600px;
+            max-height: 90vh;
+            overflow-y: auto;
+            box-shadow: 0 20px 60px rgba(0, 0, 0, 0.3);
+            animation: slideUp 0.3s;
+        }
+
+        @keyframes slideUp {
+            from {
+                transform: translateY(50px);
+                opacity: 0;
+            }
+            to {
+                transform: translateY(0);
+                opacity: 1;
+            }
+        }
+
+        .modal-header {
+            padding: 24px;
+            border-bottom: 1px solid #e5e7eb;
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+        }
+
+        .modal-title {
+            font-size: 20px;
+            font-weight: 700;
+            color: #1a1a1a;
+        }
+
+        .modal-close {
+            width: 32px;
+            height: 32px;
+            border: none;
+            background: #f3f4f6;
+            border-radius: 8px;
+            cursor: pointer;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            transition: all 0.2s;
+        }
+
+        .modal-close:hover {
+            background: #e5e7eb;
+        }
+
+        .modal-body {
+            padding: 24px;
+        }
+
+        .form-group {
+            margin-bottom: 16px;
+        }
+
+        .form-label {
+            display: block;
+            margin-bottom: 6px;
+            font-size: 14px;
+            font-weight: 500;
+            color: #374151;
+        }
+
+        .form-input {
+            width: 100%;
+            padding: 10px 12px;
+            border: 1px solid #e5e7eb;
+            border-radius: 8px;
+            font-size: 14px;
+            transition: all 0.2s;
+            background: white;
+        }
+
+        .form-input:focus {
+            outline: none;
+            border-color: #e58414;
+            box-shadow: 0 0 0 3px rgba(229,132,20,0.08);
+        }
+
+        .modal-footer {
+            padding: 20px 24px;
+            border-top: 1px solid #e5e7eb;
+            display: flex;
+            justify-content: flex-end;
+            gap: 12px;
+        }
+
+        .btn {
+            padding: 10px 20px;
+            border-radius: 8px;
+            font-size: 14px;
+            font-weight: 500;
+            cursor: pointer;
+            transition: all 0.2s;
+            border: none;
+        }
+
+        .btn-cancel {
+            background: white;
+            border: 1px solid #e5e7eb;
+            color: #6b7280;
+        }
+
+        .btn-cancel:hover {
+            background: #f3f4f6;
+        }
+
+        .btn-primary {
+            background: #e58414;
+            color: white;
+        }
+
+        .btn-primary:hover {
+            background: #d47812;
+            transform: translateY(-1px);
+            box-shadow: 0 4px 12px rgba(229,132,20,0.2);
+        }
+
+        .btn-primary:disabled {
+            background: #9ca3af;
+            cursor: not-allowed;
+            transform: none;
+        }
 
         /* Tasks */
         .task-item {
@@ -1074,6 +1233,38 @@
         </div>
     </main>
 
+    <!-- Modal dodawania notatki -->
+    <div class="modal" id="addNoteModal">
+        <div class="modal-content">
+            <div class="modal-header">
+                <h2 class="modal-title">Dodaj notatkę</h2>
+                <button class="modal-close" onclick="closeAddNoteModal()">
+                    <svg width="20" height="20" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12"></path>
+                    </svg>
+                </button>
+            </div>
+            <div class="modal-body">
+                <div class="form-group">
+                    <label class="form-label" for="noteTitle">Tytuł notatki</label>
+                    <input type="text" id="noteTitle" class="form-input" placeholder="Wprowadź tytuł">
+                </div>
+                <div class="form-group">
+                    <label class="form-label" for="noteContent">Treść</label>
+                    <textarea id="noteContent" class="form-input" rows="4" placeholder="Wpisz treść notatki"></textarea>
+                </div>
+                <div class="form-group">
+                    <label class="form-label" for="noteLink">Link</label>
+                    <input type="url" id="noteLink" class="form-input" placeholder="https://example.com">
+                </div>
+            </div>
+            <div class="modal-footer">
+                <button class="btn btn-cancel" onclick="closeAddNoteModal()">Anuluj</button>
+                <button class="btn btn-primary" onclick="saveNote()">Zapisz</button>
+            </div>
+        </div>
+    </div>
+
     <script>
         // Funkcje nawigacyjne
         function setActiveNav(element) {
@@ -1109,11 +1300,73 @@
 
         // Akcje
         function addNote() {
-            const noteContent = prompt('Treść notatki:');
-            if (noteContent) {
-                console.log('Dodawanie notatki:', noteContent);
-                alert('Notatka została dodana');
+            const modal = document.getElementById('addNoteModal');
+            if (modal) {
+                modal.classList.add('show');
             }
+        }
+
+        function closeAddNoteModal() {
+            const modal = document.getElementById('addNoteModal');
+            if (modal) {
+                modal.classList.remove('show');
+            }
+            document.getElementById('noteTitle').value = '';
+            document.getElementById('noteContent').value = '';
+            document.getElementById('noteLink').value = '';
+        }
+
+        function saveNote() {
+            const title = document.getElementById('noteTitle').value.trim();
+            const content = document.getElementById('noteContent').value.trim();
+            const link = document.getElementById('noteLink').value.trim();
+            if (!title && !content) {
+                alert('Wprowadź tytuł lub treść notatki');
+                return;
+            }
+
+            const notesTab = document.getElementById('notes-tab');
+            const noteItem = document.createElement('div');
+            noteItem.className = 'note-item';
+
+            const header = document.createElement('div');
+            header.className = 'note-header';
+
+            const author = document.createElement('span');
+            author.className = 'note-author';
+            author.textContent = 'Ty';
+
+            const date = document.createElement('span');
+            date.className = 'note-date';
+            date.textContent = new Date().toLocaleString('pl-PL');
+
+            header.appendChild(author);
+            header.appendChild(date);
+            noteItem.appendChild(header);
+
+            if (title) {
+                const noteTitle = document.createElement('div');
+                noteTitle.className = 'note-title';
+                noteTitle.textContent = title;
+                noteItem.appendChild(noteTitle);
+            }
+
+            const noteContent = document.createElement('div');
+            noteContent.className = 'note-content';
+            noteContent.textContent = content;
+            if (link) {
+                const linkEl = document.createElement('a');
+                linkEl.href = link;
+                linkEl.textContent = link;
+                linkEl.target = '_blank';
+                linkEl.style.display = 'block';
+                linkEl.style.marginTop = '8px';
+                noteContent.appendChild(linkEl);
+            }
+            noteItem.appendChild(noteContent);
+
+            notesTab.appendChild(noteItem);
+            closeAddNoteModal();
         }
 
         function addTask() {


### PR DESCRIPTION
## Summary
- add modal with fields for note title, content and link
- implement JS handlers to display the modal and append new notes
- style modal and inputs to match existing application design

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ad7551eddc83269b9c69d162f269e5