### PR TITLE
Fetch user profile after login

### DIFF
--- a/contact-details.html
+++ b/contact-details.html
@@ -2059,10 +2059,17 @@
             const userData = localStorage.getItem('userData');
             if (userData) {
                 const user = JSON.parse(userData);
-                currentUserName = user.name || 'Jan Kowalski';
+                const fullName = user.name || [user.first_name, user.last_name].filter(Boolean).join(' ');
+                currentUserName = fullName || 'Jan Kowalski';
                 document.getElementById('userName').textContent = currentUserName;
                 document.getElementById('userEmail').textContent = user.email || 'jan.kowalski@firma.pl';
-                document.getElementById('userAvatar').textContent = 'JK';
+
+                const initials = currentUserName
+                    .split(' ')
+                    .map(n => n[0])
+                    .join('')
+                    .toUpperCase();
+                document.getElementById('userAvatar').textContent = initials || 'JK';
             } else {
                 currentUserName = 'Jan Kowalski';
             }

--- a/contacts.html
+++ b/contacts.html
@@ -1147,10 +1147,15 @@
                 const userName = document.getElementById('userName');
                 const userEmail = document.getElementById('userEmail');
                 const userAvatar = document.getElementById('userAvatar');
-                
-                if (userName && user.name) {
-                    userName.textContent = user.name;
-                    const initials = user.name.split(' ').map(n => n[0]).join('').toUpperCase();
+
+                const fullName = user.name || [user.first_name, user.last_name].filter(Boolean).join(' ');
+                if (userName && fullName) {
+                    userName.textContent = fullName;
+                    const initials = fullName
+                        .split(' ')
+                        .map(n => n[0])
+                        .join('')
+                        .toUpperCase();
                     userAvatar.textContent = initials;
                 }
                 if (userEmail && user.email) {

--- a/index.html
+++ b/index.html
@@ -658,13 +658,35 @@
         // ============================================
         // OBSŁUGA SUKCESU LOGOWANIA
         // ============================================
-        function handleLoginSuccess(authData) {
+        async function handleLoginSuccess(authData) {
             const { session, user } = authData;
             if (session?.access_token) {
                 localStorage.setItem('authToken', session.access_token);
-                localStorage.setItem('userData', JSON.stringify(user));
+
+                // Pobierz dane użytkownika z bazy, aby uzyskać imię i nazwisko
+                try {
+                    const { data: profile } = await supabaseClient
+                        .from('users')
+                        .select('first_name, last_name')
+                        .eq('auth_user_id', user.id)
+                        .single();
+
+                    const userData = { ...user };
+                    if (profile) {
+                        userData.first_name = profile.first_name;
+                        userData.last_name = profile.last_name;
+                        userData.name = [profile.first_name, profile.last_name]
+                            .filter(Boolean)
+                            .join(' ');
+                    }
+
+                    localStorage.setItem('userData', JSON.stringify(userData));
+                } catch (err) {
+                    console.error('Błąd pobierania profilu użytkownika:', err);
+                    localStorage.setItem('userData', JSON.stringify(user));
+                }
             }
-            
+
             // Pokaż komunikat sukcesu
             elements.loginForm.style.display = 'none';
             elements.successMessage.classList.add('show');
@@ -704,7 +726,7 @@
                 const result = await realLogin(state.formData.email, state.formData.password);
 
                 if (result.success) {
-                    handleLoginSuccess(result.data);
+                    await handleLoginSuccess(result.data);
                 } else {
                     showGeneralError(result.error);
                     setLoadingState(false);


### PR DESCRIPTION
## Summary
- retrieve first and last name from Supabase `users` table during login and store along with auth token
- compute user avatar initials dynamically in contact details
- render stored profile name and initials in sidebar across contacts pages

## Testing
- `npm test` *(fails: ENOENT could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68adbcc1d2f48326bee7c89439e096d9