### PR TITLE
Load profile names in sidebar

### DIFF
--- a/contact-details.html
+++ b/contact-details.html
@@ -4,6 +4,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>CRM System - Szczegóły kontaktu</title>
+    <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.39.8/dist/umd/supabase.min.js"></script>
     <style>
         /* Reset i podstawowe style */
         * {
@@ -1024,10 +1025,10 @@
 
         <div class="user-section">
             <div class="user-info">
-                <div class="user-avatar" id="userAvatar">JK</div>
+                <div class="user-avatar" id="userAvatar"></div>
                 <div class="user-details">
-                    <div class="user-name" id="userName">Jan Kowalski</div>
-                    <div class="user-email" id="userEmail">jan.kowalski@firma.pl</div>
+                    <div class="user-name" id="userName"></div>
+                    <div class="user-email" id="userEmail"></div>
                 </div>
             </div>
             <button class="logout-btn" onclick="handleLogout()">
@@ -1541,7 +1542,11 @@
     </div>
 
     <script>
-        const appUsers = ['Jan Kowalski', 'Anna Nowak', 'Piotr Zieliński'];
+        const SUPABASE_URL = 'https://atbldtbvrmgoisykmizn.supabase.co';
+        const SUPABASE_ANON_KEY = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6ImF0YmxkdGJ2cm1nb2lzeWttaXpuIiwicm9sZSI6ImFub24iLCJpYXQiOjE3NTYxMTk0MDIsImV4cCI6MjA3MTY5NTQwMn0.xyC0Osw4u--L3kdCF76ih1CSLFA16FKyz9I9PNt33zI';
+        const supabaseClient = supabase.createClient(SUPABASE_URL, SUPABASE_ANON_KEY);
+
+        const appUsers = ['Anna Nowak', 'Piotr Zieliński'];
         let currentUserName = '';
 
         // Funkcje nawigacyjne
@@ -2054,26 +2059,38 @@
         }
 
         // Inicjalizacja
-        document.addEventListener('DOMContentLoaded', function() {
-            // Ustaw dane użytkownika
-            const userData = localStorage.getItem('userData');
-            if (userData) {
-                const user = JSON.parse(userData);
-                const fullName = user.name || [user.first_name, user.last_name].filter(Boolean).join(' ');
-                currentUserName = fullName || 'Jan Kowalski';
-                document.getElementById('userName').textContent = currentUserName;
-                document.getElementById('userEmail').textContent = user.email || 'jan.kowalski@firma.pl';
-
-                const initials = (user.name || '')
-               
-                    .split(' ')
-                    .map(n => n[0])
-                    .join('')
-                    .toUpperCase();
-                document.getElementById('userAvatar').textContent = initials || 'JK';
-            } else {
-                currentUserName = 'Jan Kowalski';
+        document.addEventListener('DOMContentLoaded', async function() {
+            const token = localStorage.getItem('authToken');
+            if (!token) {
+                window.location.href = 'index.html';
+                return;
             }
+
+            const { data: authData } = await supabaseClient.auth.getUser(token);
+            const login = authData?.user?.email;
+
+            if (!login) {
+                window.location.href = 'index.html';
+                return;
+            }
+
+            const { data: profile } = await supabaseClient
+                .from('profiles')
+                .select('full_name')
+                .eq('login', login)
+                .single();
+
+            const fullName = profile?.full_name || login;
+            currentUserName = fullName;
+            document.getElementById('userName').textContent = fullName;
+            document.getElementById('userEmail').textContent = login;
+
+            const initials = fullName
+                .split(' ')
+                .map(n => n[0])
+                .join('')
+                .toUpperCase();
+            document.getElementById('userAvatar').textContent = initials;
 
             const ownerSelect = document.getElementById('taskOwner');
             if (ownerSelect) {

--- a/contacts.html
+++ b/contacts.html
@@ -4,6 +4,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>CRM System - Kontakty</title>
+    <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.39.8/dist/umd/supabase.min.js"></script>
     <style>
 /* Reset i podstawowe style */
         * {
@@ -729,10 +730,10 @@
 
         <div class="user-section">
             <div class="user-info">
-                <div class="user-avatar" id="userAvatar">JK</div>
+                <div class="user-avatar" id="userAvatar"></div>
                 <div class="user-details">
-                    <div class="user-name" id="userName">Jan Kowalski</div>
-                    <div class="user-email" id="userEmail">jan.kowalski@firma.pl</div>
+                    <div class="user-name" id="userName"></div>
+                    <div class="user-email" id="userEmail"></div>
                 </div>
             </div>
             <button class="logout-btn" onclick="handleLogout()">
@@ -829,6 +830,10 @@
     </main>
 
     <script>
+        const SUPABASE_URL = 'https://atbldtbvrmgoisykmizn.supabase.co';
+        const SUPABASE_ANON_KEY = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6ImF0YmxkdGJ2cm1nb2lzeWttaXpuIiwicm9sZSI6ImFub24iLCJpYXQiOjE3NTYxMTk0MDIsImV4cCI6MjA3MTY5NTQwMn0.xyC0Osw4u--L3kdCF76ih1CSLFA16FKyz9I9PNt33zI';
+        const supabaseClient = supabase.createClient(SUPABASE_URL, SUPABASE_ANON_KEY);
+
         // ============================================
         // DANE KONTAKTÓW (DUMMY DATA)
         // ============================================
@@ -1133,36 +1138,41 @@
         // ============================================
         // INICJALIZACJA
         // ============================================
-        document.addEventListener('DOMContentLoaded', function() {
+        document.addEventListener('DOMContentLoaded', async function() {
             const token = localStorage.getItem('authToken');
             if (!token) {
                 window.location.href = 'index.html';
                 return;
             }
 
-            // Sprawdź dane użytkownika
-            const userData = localStorage.getItem('userData');
-            if (userData) {
-                const user = JSON.parse(userData);
-                const userName = document.getElementById('userName');
-                const userEmail = document.getElementById('userEmail');
-                const userAvatar = document.getElementById('userAvatar');
+            const { data: authData } = await supabaseClient.auth.getUser(token);
+            const login = authData?.user?.email;
 
-                const fullName = user.name || [user.first_name, user.last_name].filter(Boolean).join(' ');
-                if (userName && fullName) {
-                    userName.textContent = fullName;
-                    const initials = fullName
-                        .split(' ')
-                        .map(n => n[0])
-                        .join('')
-                        .toUpperCase();
-                    userAvatar.textContent = initials;
-                }
-                if (userEmail && user.email) {
-                    userEmail.textContent = user.email;
-                }
+            if (!login) {
+                window.location.href = 'index.html';
+                return;
             }
-            
+
+            const { data: profile } = await supabaseClient
+                .from('profiles')
+                .select('full_name')
+                .eq('login', login)
+                .single();
+
+            const fullName = profile?.full_name || login;
+            const userName = document.getElementById('userName');
+            const userEmail = document.getElementById('userEmail');
+            const userAvatar = document.getElementById('userAvatar');
+
+            userName.textContent = fullName;
+            userEmail.textContent = login;
+            const initials = fullName
+                .split(' ')
+                .map(n => n[0])
+                .join('')
+                .toUpperCase();
+            userAvatar.textContent = initials;
+
             // Renderuj kontakty
             renderContacts();
         });

--- a/index.html
+++ b/index.html
@@ -663,21 +663,18 @@
             if (session?.access_token) {
                 localStorage.setItem('authToken', session.access_token);
 
-                // Pobierz dane użytkownika z bazy, aby uzyskać imię i nazwisko
+                // Pobierz dane użytkownika z tabeli profiles, aby uzyskać pełne imię i nazwisko
                 try {
                     const { data: profile } = await supabaseClient
-                        .from('users')
-                        .select('first_name, last_name')
-                        .eq('auth_user_id', user.id)
+                        .from('profiles')
+                        .select('full_name')
+                        .eq('login', user.email)
                         .single();
 
                     const userData = { ...user };
                     if (profile) {
-                        userData.first_name = profile.first_name;
-                        userData.last_name = profile.last_name;
-                        userData.name = [profile.first_name, profile.last_name]
-                            .filter(Boolean)
-                            .join(' ');
+                        userData.full_name = profile.full_name;
+                        userData.name = profile.full_name;
                     }
 
                     localStorage.setItem('userData', JSON.stringify(userData));


### PR DESCRIPTION
## Summary
- replace hard-coded "Jan Kowalski" sidebar placeholder with Supabase profile `full_name`
- initialize Supabase client on contact pages and fetch profile by user login
- fetch profile full name on login for future use

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68adc236fb2c83269ec4c0b55c4aa1ec