### PR TITLE
Add sidebar links to Contacts and Projects pages

### DIFF
--- a/contact-details.html
+++ b/contact-details.html
@@ -990,7 +990,7 @@
         </div>
 
         <nav class="nav-menu">
-            <a href="#" class="nav-item active" onclick="setActiveNav(this)">
+            <a href="/contacts" class="nav-item active" onclick="setActiveNav(this)">
                 <svg class="nav-icon" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                     <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 4.354a4 4 0 110 5.292M15 21H3v-1a6 6 0 0112 0v1zm0 0h6v-1a6 6 0 00-9-5.197M13 7a4 4 0 11-8 0 4 4 0 018 0z"></path>
                 </svg>
@@ -1002,7 +1002,7 @@
                 </svg>
                 <span>CRM</span>
             </a>
-            <a href="#" class="nav-item" onclick="setActiveNav(this)">
+            <a href="/projects" class="nav-item" onclick="setActiveNav(this)">
                 <svg class="nav-icon" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                     <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z"></path>
                 </svg>

--- a/contacts.html
+++ b/contacts.html
@@ -254,7 +254,7 @@
         </div>
 
         <nav class="nav-menu">
-            <a href="#" class="nav-item active" onclick="setActiveNav(this)">
+            <a href="/contacts" class="nav-item active" onclick="setActiveNav(this)">
                 <svg class="nav-icon" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                     <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 4.354a4 4 0 110 5.292M15 21H3v-1a6 6 0 0112 0v1zm0 0h6v-1a6 6 0 00-9-5.197M13 7a4 4 0 11-8 0 4 4 0 018 0z"></path>
                 </svg>
@@ -266,7 +266,7 @@
                 </svg>
                 <span>CRM</span>
             </a>
-            <a href="#" class="nav-item" onclick="setActiveNav(this)">
+            <a href="/projects" class="nav-item" onclick="setActiveNav(this)">
                 <svg class="nav-icon" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                     <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z"></path>
                 </svg>

--- a/offers.html
+++ b/offers.html
@@ -503,7 +503,7 @@
         </div>
 
         <nav class="nav-menu">
-            <a href="#" class="nav-item" onclick="setActiveNav(this)">
+            <a href="/contacts" class="nav-item" onclick="setActiveNav(this)">
                 <svg class="nav-icon" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                     <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 4.354a4 4 0 110 5.292M15 21H3v-1a6 6 0 0112 0v1zm0 0h6v-1a6 6 0 00-9-5.197M13 7a4 4 0 11-8 0 4 4 0 018 0z"></path>
                 </svg>
@@ -515,7 +515,7 @@
                 </svg>
                 <span>CRM</span>
             </a>
-            <a href="#" class="nav-item" onclick="setActiveNav(this)">
+            <a href="/projects" class="nav-item" onclick="setActiveNav(this)">
                 <svg class="nav-icon" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                     <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z"></path>
                 </svg>

--- a/projects.html
+++ b/projects.html
@@ -667,7 +667,7 @@
         </div>
 
         <nav class="nav-menu">
-            <a href="#" class="nav-item" onclick="setActiveNav(this)">
+            <a href="/contacts" class="nav-item" onclick="setActiveNav(this)">
                 <svg class="nav-icon" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                     <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 4.354a4 4 0 110 5.292M15 21H3v-1a6 6 0 0112 0v1zm0 0h6v-1a6 6 0 00-9-5.197M13 7a4 4 0 11-8 0 4 4 0 018 0z"></path>
                 </svg>
@@ -679,7 +679,7 @@
                 </svg>
                 <span>CRM</span>
             </a>
-            <a href="#" class="nav-item active" onclick="setActiveNav(this)">
+            <a href="/projects" class="nav-item active" onclick="setActiveNav(this)">
                 <svg class="nav-icon" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                     <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z"></path>
                 </svg>


### PR DESCRIPTION
## Summary
- Enable navigation from the sidebar by linking "Kontakty" to `/contacts` and "Realizacje" to `/projects` across all pages.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68babc4e6a908326a79d07b2ce93e21e