### PR TITLE
Display active projects in green only

### DIFF
--- a/projects.html
+++ b/projects.html
@@ -308,14 +308,6 @@
             background: #10b981;
         }
 
-        .status-warning {
-            background: #fbbf24;
-        }
-
-        .status-delayed {
-            background: #ef4444;
-        }
-
         .status-completed {
             background: #9ca3af;
         }
@@ -749,9 +741,9 @@
                         </div>
                     </div>
 
-                    <!-- Project Card 2 - Warning -->
+                    <!-- Project Card 2 -->
                     <div class="project-card" onclick="openProjectDetails(2)">
-                        <div class="project-status-bar status-warning"></div>
+                        <div class="project-status-bar status-on-track"></div>
                         <div class="project-content">
                             <div class="project-header">
                                 <h3 class="project-name">Hala Produkcyjna MetalTech - Remont</h3>
@@ -824,9 +816,9 @@
                         </div>
                     </div>
 
-                    <!-- Project Card 3 - Delayed -->
+                    <!-- Project Card 3 -->
                     <div class="project-card" onclick="openProjectDetails(3)">
-                        <div class="project-status-bar status-delayed"></div>
+                        <div class="project-status-bar status-on-track"></div>
                         <div class="project-content">
                             <div class="project-header">
                                 <h3 class="project-name">Biurowiec A4 - Wymiana pokrycia</h3>


### PR DESCRIPTION
## Summary
- Remove yellow and red project status styles from `/projects` page
- Standardize active project cards to use green status bar

## Testing
- `npm test` *(fails: missing package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bea8a04c6083269cd3418a57328b10