### PR TITLE
feat: update project counters dynamically

### DIFF
--- a/projects.html
+++ b/projects.html
@@ -658,7 +658,7 @@
                     <h2 class="section-title">
                         <span class="section-indicator indicator-active"></span>
                         Aktywne inwestycje
-                        <span class="section-count">8</span>
+                        <span class="section-count" id="activeProjectsCount">0</span>
                     </h2>
                 </div>
 
@@ -899,7 +899,7 @@
                     <h2 class="section-title">
                         <span class="section-indicator indicator-completed"></span>
                         Zakończone inwestycje
-                        <span class="section-count">14</span>
+                        <span class="section-count" id="completedProjectsCount">0</span>
                     </h2>
                 </div>
 
@@ -1015,6 +1015,24 @@
             console.log('Otwieranie szczegółów projektu:', id);
         }
 
+        async function refreshProjectCounts() {
+            try {
+                const activeQuery = supabaseClient
+                    .from('projects')
+                    .select('id', { count: 'exact', head: true })
+                    .is('completed_at', null);
+                const completedQuery = supabaseClient
+                    .from('projects')
+                    .select('id', { count: 'exact', head: true })
+                    .not('completed_at', 'is', null);
+                const [{ count: activeCount }, { count: completedCount }] = await Promise.all([activeQuery, completedQuery]);
+                document.getElementById('activeProjectsCount').textContent = activeCount ?? 0;
+                document.getElementById('completedProjectsCount').textContent = completedCount ?? 0;
+            } catch(e) {
+                console.warn('refreshProjectCounts error', e);
+            }
+        }
+
         // Logout
         function handleLogout() {
             supabaseClient.auth.signOut().finally(()=>location.href='index.html');
@@ -1047,6 +1065,12 @@
                 const userAvatar = document.getElementById('userAvatar');
                 if (userAvatar) userAvatar.remove();
             } catch(e) { /* no-op */ }
+
+            refreshProjectCounts();
+            supabaseClient
+                .channel('projects-count')
+                .on('postgres_changes', { event: '*', schema: 'public', table: 'projects' }, refreshProjectCounts)
+                .subscribe();
         });
     </script>
 </body>


### PR DESCRIPTION
## Summary
- show real-time counts of active and completed investments on Projects page
- subscribe to Supabase `projects` changes to keep counters updated automatically

## Testing
- `npm test` *(fails: enoent package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68beaa8899108326977dea402e7c0bd8